### PR TITLE
Configure pre-commit to omit the {{...}} dir

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 default_language_version:
   python: python3
+exclude: ^{{
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
yaml syntax and python syntax with {{ }} vars inside it: that won't ever validate.